### PR TITLE
Keys splitted into keys and subkeys

### DIFF
--- a/src/collect/collector_base.py
+++ b/src/collect/collector_base.py
@@ -81,9 +81,17 @@ class CollectorBase(ABC):
         self.__collect_sons()
 
     def __decorate_diff(self, diff):
-        # joining by '.' if a key is a list of keys (differ's nested changes approach)
-        key = diff['changed_key'] if not isinstance(diff['changed_key'], list) else \
-            '.'.join((str(part) for part in diff['changed_key']))
+        subkey = None
+        if not isinstance(diff['changed_key'], list):
+            key = diff.get('changed_key')
+        elif len(diff.get('changed_key')) > 1:
+            key = diff.get('changed_key')[0]
+            # joining by '.' if a subkey is a list of keys (differ's nested changes approach)
+            subkey = '.'.join(str(part) for part in diff.get('changed_key')[1:])
+
+            diff.update({
+                "subkey": subkey
+            })
 
         diff.update({
             "ticker": self.ticker,
@@ -92,7 +100,7 @@ class CollectorBase(ABC):
             "source": self.name,
             "alerted": False
         })
-
+        
         return diff
 
     def __save_data(self, data):


### PR DESCRIPTION
I created a script for updating all the past diffs in the mongo so need to check it also and I'll run it on the stocker DB after merge

```python
#!/usr/bin/env python

import pymongo

from pymongo import MongoClient

DEBUG = 1

def init_mongo():
    # Using selection timeout in order to check connectivity
    try:
        mongo_client = MongoClient("mongodb+srv://stocker:halamish123@cluster2.3nsz4.mongodb.net/dev")

        # Forcing a connection to mongo
        mongo_client.server_info()

        if DEBUG:
            return mongo_client.dev
        else:
            return mongo_client.stocker

    except pymongo.errors.ServerSelectionTimeoutError:
        raise ValueError("Couldn't connect to MongoDB, check your credentials")

my_db = init_mongo()
diffs = my_db["diffs"]

for record in diffs.find():
    print("RECORD: " + str(record))
    frac_key = record['changed_key'].split('.')
    if len(frac_key) > 1:
        print("UPDATING THIS")
        diffs.find_one_and_update({"_id": record.get('_id')}, { "$set": {"changed_key": frac_key[0], "subkey": '.'.join(frac_key[1:])}})
```